### PR TITLE
Configure looping for DummyBackend

### DIFF
--- a/pynesis/backends.py
+++ b/pynesis/backends.py
@@ -227,14 +227,20 @@ class DummyBackend(Backend):
     TYPE = "dummy"
     _DEFAULT_FAKE_VALUES = [{"_id": "1", "_type": "fake", "body": "Fake event from Dummy kinesis backend"}]
 
-    def __init__(self, fake_values=None, **options):  # type: (List[Dict], Any) -> None
+    def __init__(self, fake_values=None, loop=False, **options):  # type: (List[Dict], Any, bool) -> None
         super(DummyBackend, self).__init__(**options)
         if fake_values is None:
             fake_values = self._DEFAULT_FAKE_VALUES
         self._fake_values = fake_values
+        self._loop = loop
 
     def read(self):  # type: ()->Generator[Dict, None, None]
-        for message in cycle(self._fake_values):
+        if self._loop:
+            fake_values = cycle(self._fake_values)
+        else:
+            fake_values = self._fake_values
+
+        for message in fake_values:
             yield message
             if self._stop:
                 break

--- a/pynesis/backends.py
+++ b/pynesis/backends.py
@@ -227,7 +227,7 @@ class DummyBackend(Backend):
     TYPE = "dummy"
     _DEFAULT_FAKE_VALUES = [{"_id": "1", "_type": "fake", "body": "Fake event from Dummy kinesis backend"}]
 
-    def __init__(self, fake_values=None, loop=True, **options):  # type: (List[Dict], Any, bool) -> None
+    def __init__(self, fake_values=None, loop=True, **options):  # type: (List[Dict], bool, Any) -> None
         super(DummyBackend, self).__init__(**options)
         if fake_values is None:
             fake_values = self._DEFAULT_FAKE_VALUES

--- a/pynesis/backends.py
+++ b/pynesis/backends.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 from itertools import cycle
 from threading import local
-from typing import Dict, Generator, List, Optional, Tuple, Any  # noqa
+from typing import Dict, Generator, List, Optional, Tuple, Iterable, Any  # noqa
 
 import boto3
 from six import with_metaclass
@@ -227,7 +227,7 @@ class DummyBackend(Backend):
     TYPE = "dummy"
     _DEFAULT_FAKE_VALUES = [{"_id": "1", "_type": "fake", "body": "Fake event from Dummy kinesis backend"}]
 
-    def __init__(self, fake_values=None, loop=False, **options):  # type: (List[Dict], Any, bool) -> None
+    def __init__(self, fake_values=None, loop=True, **options):  # type: (List[Dict], Any, bool) -> None
         super(DummyBackend, self).__init__(**options)
         if fake_values is None:
             fake_values = self._DEFAULT_FAKE_VALUES
@@ -235,10 +235,9 @@ class DummyBackend(Backend):
         self._loop = loop
 
     def read(self):  # type: ()->Generator[Dict, None, None]
+        fake_values = self._fake_values  # type: Iterable
         if self._loop:
             fake_values = cycle(self._fake_values)
-        else:
-            fake_values = self._fake_values
 
         for message in fake_values:
             yield message

--- a/pynesis/tests/backends_tests.py
+++ b/pynesis/tests/backends_tests.py
@@ -1,3 +1,4 @@
+import pytest
 from mock import MagicMock, call
 
 from pynesis.checkpointers import Checkpointer
@@ -14,7 +15,7 @@ def test_kinesis_record():
 def test_dummy_backend(mocker):
     time_mock = mocker.patch(backends.__name__ + ".time")
     dummy_backend = backends.DummyBackend(
-        fake_values=[{"_key": "123", "some": "thing"}, {"_key": "2", "other": "stuff"}])
+        fake_values=[{"_key": "123", "some": "thing"}, {"_key": "2", "other": "stuff"}], loop=True)
 
     generator = dummy_backend.read()
 
@@ -25,6 +26,20 @@ def test_dummy_backend(mocker):
     message = next(generator)
     assert message == {"_key": "123", "some": "thing"}
     assert len(time_mock.sleep.mock_calls) == 2
+
+
+def test_dummy_backend_without_loop():
+    dummy_backend = backends.DummyBackend(
+        fake_values=[{"_key": "123", "some": "thing"}, {"_key": "2", "other": "stuff"}], loop=False)
+
+    generator = dummy_backend.read()
+
+    message = next(generator)
+    assert message == {"_key": "123", "some": "thing"}
+    message = next(generator)
+    assert message == {"_key": "2", "other": "stuff"}
+    with pytest.raises(StopIteration):
+        next(generator)
 
 
 def test_kinesis_backend(kinesis_client):


### PR DESCRIPTION
This PR allows to use a config value `loop: False` to avoid cycling when use DummyBackend with fake_values.