### PR TITLE
Use logger in DummyStream

### DIFF
--- a/pynesis/streams.py
+++ b/pynesis/streams.py
@@ -244,4 +244,4 @@ class DummyStream(Stream):
             time.sleep(1)
 
     def put(self, key, data):  # type: (str,bytes) -> None
-        print("Sending outgoing message to eventbus: {}".format(str(data)))
+        logger.info("Sending outgoing message to eventbus: {}".format(str(data)))


### PR DESCRIPTION
With `puts`, it requires to flush buffer each time, or it will be flushed only when worker finishes, that is:

```python
import sys
sys.stdout.flush()
```
Using logger, will fix that.