### PR TITLE
Raise custom exception on read instead of boto3 ones

### DIFF
--- a/pynesis/tests/streams_tests.py
+++ b/pynesis/tests/streams_tests.py
@@ -94,3 +94,17 @@ def test_kinesis_backend_put(kinesis_client):
 
     assert kinesis_client.put_record.mock_calls == [
         call(Data=b"some bytes", PartitionKey="123", StreamName="test-streams")]
+
+
+def test_kinesis_custom_exception_on_read(failing_kinesis_client):
+    kinesis_backend = streams.KinesisStream(
+        stream_name="test-stream",
+        region_name="us-east-1",
+        batch_size=10,
+        kinesis_client=failing_kinesis_client,
+    )
+
+    generator = kinesis_backend.read()
+
+    with pytest.raises(streams.StreamReadingException):
+        next(generator)


### PR DESCRIPTION
When having spikes in kinesis traffic, we can hit `ProvisionedThroughputExceededException` errors while doing reads to kinesis streams.

Pynesis already allows to lower batch size and increase the read delay, but if we still hit the 2MB/sec rate limit (or [a similar one](http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html)), a boto3 exception is raised outside of pynesis.

This PR adds a custom `StreamReadingException` so any customer of pynesis can easily handle all read errors if they wish to, without needing to import boto3.